### PR TITLE
Support GHC 8.4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for schematic
 
+## HEAD
+
+Support ghc-8.4 and drop support for older versions
+
 ## 0.4.1.0 -- 2017-11-05
 
 Convenience isomorphisms: txt, num, opt, bln etc

--- a/schematic.cabal
+++ b/schematic.cabal
@@ -57,7 +57,7 @@ library
                      , TypeOperators
                      , TypeSynonymInstances
                      , UndecidableInstances
-  build-depends:       base >=4.9 && <4.11
+  build-depends:       base >=4.9 && <4.12
                      , bytestring
                      , aeson >= 1
                      , containers
@@ -67,7 +67,7 @@ library
                      , regex-tdfa
                      , regex-tdfa-text
                      , scientific
-                     , singletons >= 2.2
+                     , singletons >= 2.4
                      , smallcheck
                      , tagged
                      , template-haskell
@@ -87,7 +87,7 @@ test-suite spec
   default-language:   Haskell2010
   build-depends:       HUnit
                      , aeson >= 1
-                     , base >=4.9 && <4.11
+                     , base >=4.9 && <4.12
                      , bytestring
                      , containers
                      , hjsonschema

--- a/schematic.cabal
+++ b/schematic.cabal
@@ -57,7 +57,7 @@ library
                      , TypeOperators
                      , TypeSynonymInstances
                      , UndecidableInstances
-  build-depends:       base >=4.9 && <4.12
+  build-depends:       base >=4.11 && <4.12
                      , bytestring
                      , aeson >= 1
                      , containers
@@ -74,7 +74,7 @@ library
                      , text
                      , union
                      , unordered-containers
-                     , validationt >= 0.1.0.1
+                     , validationt >= 0.2.1.0
                      , vector
                      , vinyl
   hs-source-dirs:      src
@@ -87,7 +87,7 @@ test-suite spec
   default-language:   Haskell2010
   build-depends:       HUnit
                      , aeson >= 1
-                     , base >=4.9 && <4.12
+                     , base >=4.11 && <4.12
                      , bytestring
                      , containers
                      , hjsonschema
@@ -104,7 +104,7 @@ test-suite spec
                      , tagged
                      , text
                      , unordered-containers
-                     , validationt >= 0.1.0.1
+                     , validationt >= 0.2.1.0
                      , vinyl
   other-modules:       SchemaSpec
                      , HelpersSpec

--- a/src/Data/Schematic/Migration.hs
+++ b/src/Data/Schematic/Migration.hs
@@ -42,8 +42,8 @@ type family SchemaByKey (fs :: [(Symbol, Schema)]) (s :: Symbol) :: Schema where
   SchemaByKey ( '(a, s) ': tl) fn = SchemaByKey tl fn
 
 type family DeleteKey (acc :: [(Symbol, Schema)]) (fn :: Symbol) (fs :: [(Symbol, Schema)]) :: [(Symbol, Schema)] where
-  DeleteKey acc fn ('(fn, a) ': tl) = acc :++ tl
-  DeleteKey acc fn (fna ': tl) = acc :++ (fna ': tl)
+  DeleteKey acc fn ('(fn, a) ': tl) = acc ++ tl
+  DeleteKey acc fn (fna ': tl) = acc ++ (fna ': tl)
 
 type family UpdateKey
   (fn :: Symbol)
@@ -146,7 +146,7 @@ data instance Sing (v :: Versioned) where
 
 type DataMigration s m h = Tagged s (JsonRepr h -> m (JsonRepr s))
 
-data MList :: (* -> *) -> [Schema] -> Type where
+data MList :: (Type -> Type) -> [Schema] -> Type where
   MNil :: (Monad m, SingI s, TopLevel s) => MList m '[s]
   (:&&)
     :: (TopLevel s, SingI s)

--- a/src/Data/Schematic/Path.hs
+++ b/src/Data/Schematic/Path.hs
@@ -1,7 +1,6 @@
 module Data.Schematic.Path where
 
 import Data.Foldable as F
-import Data.Monoid
 import Data.Singletons.Prelude
 import Data.Singletons.TypeLits
 import Data.Text as T

--- a/src/Data/Schematic/Path.hs
+++ b/src/Data/Schematic/Path.hs
@@ -2,7 +2,6 @@ module Data.Schematic.Path where
 
 import Data.Foldable as F
 import Data.Monoid
-import Data.Singletons
 import Data.Singletons.Prelude
 import Data.Singletons.TypeLits
 import Data.Text as T
@@ -26,10 +25,10 @@ demotePath = go []
   where
     go :: [DemotedPathSegment] -> Sing (ps :: [PathSegment]) -> [DemotedPathSegment]
     go acc SNil = acc
-    go acc (SCons p ps) = go (acc ++ [demote p]) ps
-    demote :: Sing (ps :: PathSegment) -> DemotedPathSegment
-    demote (SKey s) = DKey $ T.pack $ withKnownSymbol s $ symbolVal s
-    demote (SIx n) = DIx $ withKnownNat n $ fromIntegral $ natVal n
+    go acc (SCons p ps) = go (acc ++ [demotePathSeg p]) ps
+    demotePathSeg :: Sing (ps :: PathSegment) -> DemotedPathSegment
+    demotePathSeg (SKey s) = DKey $ T.pack $ withKnownSymbol s $ symbolVal s
+    demotePathSeg (SIx n) = DIx $ withKnownNat n $ fromIntegral $ natVal n
 
 demotedPathToText :: [DemotedPathSegment] -> JSONPath
 demotedPathToText = JSONPath . F.foldl' renderPathSegment ""

--- a/src/Data/Schematic/Path.hs
+++ b/src/Data/Schematic/Path.hs
@@ -29,7 +29,7 @@ demotePath = go []
     go acc (SCons p ps) = go (acc ++ [demote p]) ps
     demote :: Sing (ps :: PathSegment) -> DemotedPathSegment
     demote (SKey s) = DKey $ T.pack $ withKnownSymbol s $ symbolVal s
-    demote (SIx n) = DIx $ withKnownNat n $ natVal n
+    demote (SIx n) = DIx $ withKnownNat n $ fromIntegral $ natVal n
 
 demotedPathToText :: [DemotedPathSegment] -> JSONPath
 demotedPathToText = JSONPath . F.foldl' renderPathSegment ""

--- a/src/Data/Schematic/Schema.hs
+++ b/src/Data/Schematic/Schema.hs
@@ -48,11 +48,11 @@ data TextConstraint
 instance SingKind TextConstraint where
   type Demote TextConstraint = DemotedTextConstraint
   fromSing = \case
-    STEq n -> withKnownNat n (DTEq $ natVal n)
-    STLt n -> withKnownNat n (DTLt $ natVal n)
-    STLe n -> withKnownNat n (DTLe $ natVal n)
-    STGt n -> withKnownNat n (DTGt $ natVal n)
-    STGe n -> withKnownNat n (DTGe $ natVal n)
+    STEq n -> withKnownNat n (DTEq . fromIntegral $ natVal n)
+    STLt n -> withKnownNat n (DTLt . fromIntegral $ natVal n)
+    STLe n -> withKnownNat n (DTLe . fromIntegral $ natVal n)
+    STGt n -> withKnownNat n (DTGt . fromIntegral $ natVal n)
+    STGe n -> withKnownNat n (DTGe . fromIntegral $ natVal n)
     STRegex s -> withKnownSymbol s (DTRegex $ T.pack $ symbolVal s)
     STEnum s -> let
       d :: Sing (s :: [Symbol]) -> [Text]
@@ -153,11 +153,11 @@ instance Eq (Sing ('NGe n)) where _ == _ = True
 instance SingKind NumberConstraint where
   type Demote NumberConstraint = DemotedNumberConstraint
   fromSing = \case
-    SNEq n -> withKnownNat n (DNEq $ natVal n)
-    SNGt n -> withKnownNat n (DNGt $ natVal n)
-    SNGe n -> withKnownNat n (DNGe $ natVal n)
-    SNLt n -> withKnownNat n (DNLt $ natVal n)
-    SNLe n -> withKnownNat n (DNLe $ natVal n)
+    SNEq n -> withKnownNat n (DNEq . fromIntegral $ natVal n)
+    SNGt n -> withKnownNat n (DNGt . fromIntegral $ natVal n)
+    SNGe n -> withKnownNat n (DNGe . fromIntegral $ natVal n)
+    SNLt n -> withKnownNat n (DNLt . fromIntegral $ natVal n)
+    SNLe n -> withKnownNat n (DNLe . fromIntegral $ natVal n)
   toSing = \case
     DNEq n -> case someNatVal n of
       Just (SomeNat (_ :: Proxy n)) -> SomeSing (SNEq (SNat :: Sing n))
@@ -193,7 +193,7 @@ instance Eq (Sing ('AEq n)) where _ == _ = True
 instance SingKind ArrayConstraint where
   type Demote ArrayConstraint = DemotedArrayConstraint
   fromSing = \case
-    SAEq n -> withKnownNat n (DAEq $ natVal n)
+    SAEq n -> withKnownNat n (DAEq . fromIntegral $ natVal n)
   toSing = \case
     DAEq n -> case someNatVal n of
       Just (SomeNat (_ :: Proxy n)) -> SomeSing (SAEq (SNat :: Sing n))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,12 @@
-resolver: lts-10.0
+resolver: nightly-2018-04-05
+extra-deps:
+  - transformers-lift-0.2.0.1
+  - union-0.1.1.2
+  - QuickCheck-2.10.1
+  - http-types-0.9.1
+  - git: https://github.com/4e6/validationt.git
+    commit: b1ec01576114595c109d3e86f4cb2fad3de43b43
+  - git: https://github.com/4e6/hjsonpointer.git
+    commit: 53833ce632b84eb209dea6748ad642502a02249a
+  - git: https://github.com/4e6/hjsonschema.git
+    commit: 370cee6aab20157bee0c00d5f2cb01c6221610f1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,5 @@
-resolver: nightly-2018-04-05
+resolver: lts-12.0
 extra-deps:
-  - transformers-lift-0.2.0.1
-  - union-0.1.1.2
-  - QuickCheck-2.10.1
-  - http-types-0.9.1
-  - git: https://github.com/4e6/validationt.git
-    commit: b1ec01576114595c109d3e86f4cb2fad3de43b43
-  - git: https://github.com/4e6/hjsonpointer.git
-    commit: 53833ce632b84eb209dea6748ad642502a02249a
-  - git: https://github.com/4e6/hjsonschema.git
-    commit: 370cee6aab20157bee0c00d5f2cb01c6221610f1
+  - hjsonpointer-1.4.0@rev:0
+  - hjsonschema-1.9.0@rev:0
+  - validationt-0.2.1.0


### PR DESCRIPTION
- Add ghc-8.4 support
- Drop suport for older GHCs because [singletons-2.4.1](https://hackage.haskell.org/package/singletons-2.4.1) now target only the latest ghc-8.4 with `base ==0.11.*` constraint