### PR TITLE
Add array constraints. Fix the generation of text and number constrai…

### DIFF
--- a/src/Data/Schematic/JsonSchema.hs
+++ b/src/Data/Schematic/JsonSchema.hs
@@ -30,13 +30,13 @@ textConstraint :: DemotedTextConstraint -> State D4.Schema ()
 textConstraint (DTEq n) = modify $ \s -> s
   { _schemaMinLength = pure $ fromIntegral n
   , _schemaMaxLength = pure $ fromIntegral n }
-textConstraint (DTLt n) = modify $ \s -> s
-  { _schemaMaxLength = pure . fromIntegral $ n + 1 }
 textConstraint (DTLe n) = modify $ \s -> s
   { _schemaMaxLength = pure . fromIntegral $ n }
-textConstraint (DTGt n) =
+textConstraint (DTLt n) =
   let n' = if n == 0 then 0 else n - 1
-  in modify $ \s -> s { _schemaMinLength = pure . fromIntegral $ n' }
+  in modify $ \s -> s { _schemaMaxLength = pure . fromIntegral $ n' }
+textConstraint (DTGt n) = modify $ \s -> s
+  { _schemaMinLength = pure . fromIntegral $ n + 1 }
 textConstraint (DTGe n) = modify $ \s -> s
   { _schemaMinLength = pure . fromIntegral $ n }
 textConstraint (DTRegex r) = modify $ \s -> s { _schemaPattern = pure r }
@@ -47,19 +47,30 @@ textConstraint (DTEnum ss) =
 numberConstraint :: DemotedNumberConstraint -> State D4.Schema ()
 numberConstraint (DNLe n) = modify $ \s -> s
   { _schemaMaximum = pure . fromIntegral $ n }
-numberConstraint (DNLt n) = modify $ \s -> s
-  { _schemaMaximum = pure . fromIntegral $ n + 1 }
-numberConstraint (DNGt n) = modify $ \s -> s
-  { _schemaMinimum = pure . fromIntegral $ n }
-numberConstraint (DNGe n) =
+numberConstraint (DNLt n) =
   let n' = if n == 0 then 0 else n - 1
-  in modify $ \s -> s { _schemaMinimum = pure . fromIntegral $ n' }
+  in modify $ \s -> s { _schemaMaximum = pure . fromIntegral $ n' }
+numberConstraint (DNGt n) = modify $ \s -> s
+  { _schemaMinimum = pure . fromIntegral $ n + 1 }
+numberConstraint (DNGe n) = modify $ \s -> s
+  { _schemaMinimum = pure . fromIntegral $ n }
 numberConstraint (DNEq n) = modify $ \s -> s
   { _schemaMinimum = pure $ fromIntegral n
   , _schemaMaximum = pure $ fromIntegral n }
 
 arrayConstraint :: DemotedArrayConstraint -> State D4.Schema ()
-arrayConstraint (DAEq _) = pure ()
+arrayConstraint (DALe n) = modify $ \s -> s
+  { _schemaMaxItems = pure . fromIntegral $ n }
+arrayConstraint (DALt n) =
+  let n' = if n == 0 then 0 else n - 1
+  in modify $ \s -> s { _schemaMaxItems = pure . fromIntegral $ n' }
+arrayConstraint (DAGt n) = modify $ \s -> s
+  { _schemaMinItems = pure . fromIntegral $ n + 1 }
+arrayConstraint (DAGe n) = modify $ \s -> s
+  { _schemaMinItems = pure . fromIntegral $ n }
+arrayConstraint (DAEq n) = modify $ \s -> s
+  { _schemaMinItems = pure $ fromIntegral n
+  , _schemaMaxItems = pure $ fromIntegral n }
 
 toJsonSchema
   :: forall proxy schema

--- a/src/Data/Schematic/Schema.hs
+++ b/src/Data/Schematic/Schema.hs
@@ -180,26 +180,62 @@ instance SingKind NumberConstraint where
 
 data ArrayConstraint
   = AEq Nat
+  | AGt Nat
+  | AGe Nat
+  | ALt Nat
+  | ALe Nat
   deriving (Generic)
 
 data DemotedArrayConstraint
   = DAEq Integer
+  | DAGt Integer
+  | DAGe Integer
+  | DALt Integer
+  | DALe Integer
   deriving (Generic, Eq, Show)
 
 data instance Sing (ac :: ArrayConstraint) where
   SAEq :: Sing n -> Sing ('AEq n)
+  SAGt :: Sing n -> Sing ('AGt n)
+  SAGe :: Sing n -> Sing ('AGe n)
+  SALt :: Sing n -> Sing ('ALt n)
+  SALe :: Sing n -> Sing ('ALe n)
 
 instance KnownNat n => SingI ('AEq n) where sing = SAEq sing
+instance KnownNat n => SingI ('AGt n) where sing = SAGt sing
+instance KnownNat n => SingI ('AGe n) where sing = SAGe sing
+instance KnownNat n => SingI ('ALt n) where sing = SALt sing
+instance KnownNat n => SingI ('ALe n) where sing = SALe sing
 
 instance Eq (Sing ('AEq n)) where _ == _ = True
+instance Eq (Sing ('AGt n)) where _ == _ = True
+instance Eq (Sing ('AGe n)) where _ == _ = True
+instance Eq (Sing ('ALt n)) where _ == _ = True
+instance Eq (Sing ('ALe n)) where _ == _ = True
 
 instance SingKind ArrayConstraint where
   type Demote ArrayConstraint = DemotedArrayConstraint
   fromSing = \case
     SAEq n -> withKnownNat n (DAEq . fromIntegral $ natVal n)
+    SAGt n -> withKnownNat n (DAGt . fromIntegral $ natVal n)
+    SAGe n -> withKnownNat n (DAGe . fromIntegral $ natVal n)
+    SALt n -> withKnownNat n (DALt . fromIntegral $ natVal n)
+    SALe n -> withKnownNat n (DALe . fromIntegral $ natVal n)
   toSing = \case
     DAEq n -> case someNatVal n of
       Just (SomeNat (_ :: Proxy n)) -> SomeSing (SAEq (SNat :: Sing n))
+      Nothing                       -> error "Negative singleton nat"
+    DAGt n -> case someNatVal n of
+      Just (SomeNat (_ :: Proxy n)) -> SomeSing (SAGt (SNat :: Sing n))
+      Nothing                       -> error "Negative singleton nat"
+    DAGe n -> case someNatVal n of
+      Just (SomeNat (_ :: Proxy n)) -> SomeSing (SAGe (SNat :: Sing n))
+      Nothing                       -> error "Negative singleton nat"
+    DALt n -> case someNatVal n of
+      Just (SomeNat (_ :: Proxy n)) -> SomeSing (SALt (SNat :: Sing n))
+      Nothing                       -> error "Negative singleton nat"
+    DALe n -> case someNatVal n of
+      Just (SomeNat (_ :: Proxy n)) -> SomeSing (SALe (SNat :: Sing n))
       Nothing                       -> error "Negative singleton nat"
 
 data Schema

--- a/src/Data/Schematic/Schema.hs-boot
+++ b/src/Data/Schematic/Schema.hs-boot
@@ -46,9 +46,17 @@ data DemotedNumberConstraint
 
 data ArrayConstraint
   = AEq Nat
+  | AGt Nat
+  | AGe Nat
+  | ALt Nat
+  | ALe Nat
 
 data DemotedArrayConstraint
   = DAEq Integer
+  | DAGt Integer
+  | DAGe Integer
+  | DALt Integer
+  | DALe Integer
 
 data Schema
   = SchemaText [TextConstraint]

--- a/src/Data/Schematic/Validation.hs
+++ b/src/Data/Schematic/Validation.hs
@@ -160,6 +160,34 @@ validateArrayConstraint (JSONPath path) v = \case
       errMsg    = "length should be == " <> T.pack (show nlen)
       warn      = vWarning $ mmSingleton path (pure errMsg)
     unless predicate warn
+  SAGt n -> do
+    let
+      nlen      = withKnownNat n $ natVal n
+      predicate = fromIntegral (V.length v) > nlen
+      errMsg    = "length should be > " <> T.pack (show nlen)
+      warn      = vWarning $ mmSingleton path (pure errMsg)
+    unless predicate warn
+  SAGe n -> do
+    let
+      nlen      = withKnownNat n $ natVal n
+      predicate = fromIntegral (V.length v) >= nlen
+      errMsg    = "length should be >= " <> T.pack (show nlen)
+      warn      = vWarning $ mmSingleton path (pure errMsg)
+    unless predicate warn
+  SALt n -> do
+    let
+      nlen      = withKnownNat n $ natVal n
+      predicate = fromIntegral (V.length v) < nlen
+      errMsg    = "length should be < " <> T.pack (show nlen)
+      warn      = vWarning $ mmSingleton path (pure errMsg)
+    unless predicate warn
+  SALe n -> do
+    let
+      nlen      = withKnownNat n $ natVal n
+      predicate = fromIntegral (V.length v) <= nlen
+      errMsg    = "length should be <= " <> T.pack (show nlen)
+      warn      = vWarning $ mmSingleton path (pure errMsg)
+    unless predicate warn
 
 validateJsonRepr
   :: Sing schema

--- a/test/JsonSchemaSpec.hs
+++ b/test/JsonSchemaSpec.hs
@@ -10,6 +10,7 @@ module JsonSchemaSpec (spec, main) where
 import Data.Aeson as J
 import Data.Maybe
 import Data.Proxy
+import Data.ByteString.Lazy as B
 import Data.Schematic
 import Data.Vinyl
 import JSONSchema.Draft4 as D4
@@ -31,12 +32,69 @@ exampleData = withRepr @SchemaExample $
   :& field @"bar" (pure (ReprText "foo"))
   :& RNil
 
+type SchemaArrayExample = 'SchemaObject
+  '[ '("a1", 'SchemaArray '[ 'AGt 1 ] ('SchemaNumber '[]))
+  ,  '("a2", 'SchemaArray '[ 'AGe 1 ] ('SchemaNumber '[]))
+  ,  '("a3", 'SchemaArray '[ 'ALt 1 ] ('SchemaNumber '[]))
+  ,  '("a4", 'SchemaArray '[ 'ALe 1 ] ('SchemaNumber '[]))
+  ]
+
+type SchemaNumberExample = 'SchemaObject
+  '[ '("n1", 'SchemaNumber '[ 'NGt 1 ])
+  ,  '("n2", 'SchemaNumber '[ 'NGe 1 ])
+  ,  '("n3", 'SchemaNumber '[ 'NLt 1 ])
+  ,  '("n4", 'SchemaNumber '[ 'NLe 1 ])
+  ]
+
+type SchemaTextExample = 'SchemaObject
+  '[ '("t1", 'SchemaText '[ 'TGt 1 ])
+  ,  '("t2", 'SchemaText '[ 'TGe 1 ])
+  ,  '("t3", 'SchemaText '[ 'TLt 1 ])
+  ,  '("t4", 'SchemaText '[ 'TLe 1 ])
+  ]
+
 spec :: Spec
 spec = do
   it "validates simple schema" $ do
     let schema = D4.SchemaWithURI (fromJust $ toJsonSchema (Proxy @SchemaExample)) Nothing
     fetchHTTPAndValidate schema (toJSON exampleData) >>= \case
       Left _ -> fail "failed to validate test example"
+      Right _ -> pure ()
+  it "validates schema with arrays" $ do
+    let
+      schema = D4.SchemaWithURI (fromJust $ toJsonSchema (Proxy @SchemaArrayExample)) Nothing
+      obj = withRepr @SchemaArrayExample $
+           field @"a1" [ReprNumber 13, ReprNumber 13]
+        :& field @"a2" [ReprNumber 13]
+        :& field @"a3" []
+        :& field @"a4" [ReprNumber 13]
+        :& RNil
+    fetchHTTPAndValidate schema (toJSON obj) >>= \case
+      Left e -> fail "failed to validate test example"
+      Right _ -> pure ()
+  it "validates schema with numbers" $ do
+    let
+      schema = D4.SchemaWithURI (fromJust $ toJsonSchema (Proxy @SchemaNumberExample)) Nothing
+      obj = withRepr @SchemaNumberExample $
+           field @"n1" 2
+        :& field @"n2" 1
+        :& field @"n3" 0
+        :& field @"n4" 1
+        :& RNil
+    fetchHTTPAndValidate schema (toJSON obj) >>= \case
+      Left e -> fail "failed to validate test example"
+      Right _ -> pure ()
+  it "validates schema with strings" $ do
+    let
+      schema = D4.SchemaWithURI (fromJust $ toJsonSchema (Proxy @SchemaTextExample)) Nothing
+      obj = withRepr @SchemaTextExample $
+           field @"t1" "11"
+        :& field @"t2" "1"
+        :& field @"t3" ""
+        :& field @"t4" "1"
+        :& RNil
+    fetchHTTPAndValidate schema (toJSON obj) >>= \case
+      Left e -> fail "failed to validate test example"
       Right _ -> pure ()
 
 main :: IO ()


### PR DESCRIPTION
- Add array constraints: `AGt`, `AGe`, `ALt`, `ALe`.
- Fix the json schema generation of text and number constraints.