### PR TITLE
Fix the generation of json schema for numbers.

### DIFF
--- a/src/Data/Schematic/JsonSchema.hs
+++ b/src/Data/Schematic/JsonSchema.hs
@@ -47,11 +47,12 @@ textConstraint (DTEnum ss) =
 numberConstraint :: DemotedNumberConstraint -> State D4.Schema ()
 numberConstraint (DNLe n) = modify $ \s -> s
   { _schemaMaximum = pure . fromIntegral $ n }
-numberConstraint (DNLt n) =
-  let n' = if n == 0 then 0 else n - 1
-  in modify $ \s -> s { _schemaMaximum = pure . fromIntegral $ n' }
+numberConstraint (DNLt n) = modify $ \s -> s
+  { _schemaMaximum = pure . fromIntegral $ n
+  , _schemaExclusiveMaximum = pure True }
 numberConstraint (DNGt n) = modify $ \s -> s
-  { _schemaMinimum = pure . fromIntegral $ n + 1 }
+  { _schemaMinimum = pure . fromIntegral $ n
+  , _schemaExclusiveMinimum = pure True }
 numberConstraint (DNGe n) = modify $ \s -> s
   { _schemaMinimum = pure . fromIntegral $ n }
 numberConstraint (DNEq n) = modify $ \s -> s

--- a/test/JsonSchemaSpec.hs
+++ b/test/JsonSchemaSpec.hs
@@ -76,10 +76,10 @@ spec = do
     let
       schema = D4.SchemaWithURI (fromJust $ toJsonSchema (Proxy @SchemaNumberExample)) Nothing
       obj = withRepr @SchemaNumberExample $
-           field @"n1" 2
+           field @"n1" 1.1
         :& field @"n2" 1
-        :& field @"n3" 0
-        :& field @"n4" 1
+        :& field @"n3" 0.9
+        :& field @"n4" 1.0
         :& RNil
     fetchHTTPAndValidate schema (toJSON obj) >>= \case
       Left e -> fail "failed to validate test example"


### PR DESCRIPTION
This pr adds `exclusiveMinimum` and `exclusiveMaximum` attributes to number constraints. That fixes the behaviour with float numbers.