### PR TITLE
Migrated to be compatible with lts-14.22

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for schematic
 
+## 0.6.0.0 -- 2020-02-04
+
+Added compatability with aeson-1.4.3.0. Since version 1.4.3 the module `Data.Aeson` started exporting `JSONPath`, which was conflicting with our own `JSONPath`. Furthermore, started using `JSONPathElement` from `aeson` instead of `DemotedPathSegment`.
+
 ## 0.5.0.0 -- 2019-02-20
 
 GHC 8.6, json generation by schema definition, validation bug fixes, better

--- a/schematic.cabal
+++ b/schematic.cabal
@@ -1,5 +1,5 @@
 name:                schematic
-version:             0.5.0.0
+version:             0.6.0.0
 synopsis:            JSON-biased spec and validation tool
 description:         JSON-biased spec and validation tool. Makes possible to have a schema as a haskell type and derive json instances, validation actions, JSON generation for property-test generically. Built-in lens support.
 license:             BSD3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
-resolver: lts-12.0
+resolver: lts-14.22
 extra-deps:
-  - hjsonpointer-1.4.0@rev:0
-  - hjsonschema-1.9.0@rev:0
-  - validationt-0.2.1.0
+- hjsonpointer-1.4.0@rev:0
+- hjsonschema-1.9.0@rev:0
+- git: https://github.com/typeable/validationt.git
+  commit: 97fea97c4015ab5e99f3efb2c73e1fef4b8857d8


### PR DESCRIPTION
Added compatability with aeson-1.4.3.0. Since version 1.4.3 the module `Data.Aeson` started exporting `JSONPath`, which was conflicting with our own `JSONPath`.

Furthermore, since we are already breaking the API, started using `JSONPathElement` from `aeson` instead of `DemotedPathSegment`, since they were basically the same structure.
